### PR TITLE
invader rune

### DIFF
--- a/katana/point-invader.json
+++ b/katana/point-invader.json
@@ -19,6 +19,6 @@
   },
   "reward": [
     "random-money %player% 2.0 8.0",
-    "point-lootbox-reward %player% PET 15.0 1"
+    "point-lootbox-reward %player% PET 40.0 1"
   ]
 }

--- a/katana/runes.json
+++ b/katana/runes.json
@@ -121,9 +121,9 @@
       "notify": false,
       "canDrop": true,
       "upgradeText": "katana.runes.increase.ability.upgrade.name",
-      "current": 25.0,
-      "per": 1.25,
-      "max": 60.0,
+      "current": 45,
+      "per": 1,
+      "max": 61,
       "isPercent": true
     },
     "COLLECTOR": {


### PR DESCRIPTION
chance point-invader

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Increase the reward probability for the "point-lootbox-reward" from 15.0 to 40.0 in `point-invader.json` and adjust the "current", "per", and "max" values for the "invader" rune in `runes.json`.

### Why are these changes being made?

These changes are being made to enhance the gameplay experience by increasing the likelihood of receiving a PET reward, and to balance the rune upgrade system by adjusting its progression metrics. The adjustments aim to make the rewards more appealing and the rune upgrades more consistent with player expectations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->