### PR TITLE
fix battleship-rune max

### DIFF
--- a/katana/runes.json
+++ b/katana/runes.json
@@ -198,7 +198,7 @@
       "upgradeText": "katana.runes.increase.ability.upgrade.name",
       "current": 20.0,
       "per": 20.0,
-      "max": 340.0,
+      "max": 100.0,
       "isPercent": true
     },
     "KEEPER": {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Reduce the maximum value of the "battleship-rune" from 340.0 to 100.0 in the `katana/runes.json` file.

### Why are these changes being made?

The change corrects an error in the maximum value for the "battleship-rune" to align with the intended game balance and design specifications. The previous value was likely a typo or oversight, and this adjustment ensures consistency with other rune configurations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->