### PR TITLE
bb

### DIFF
--- a/destructions/rebirth.json
+++ b/destructions/rebirth.json
@@ -2028,1003 +2028,1003 @@
       }
     },
     "201": {
-      "price": 1000000000000000000000000000,
-      "level": 7,
+      "price": 1620000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "202": {
-      "price": 133000000000,
-      "level": 7,
+      "price": 175000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "203": {
-      "price": 134000000000,
-      "level": 7,
+      "price": 190000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "204": {
-      "price": 135000000000,
-      "level": 7,
+      "price": 205000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "205": {
-      "price": 136000000000,
-      "level": 7,
+      "price": 222000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "206": {
-      "price": 137000000000,
-      "level": 7,
+      "price": 241000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "207": {
-      "price": 138000000000,
-      "level": 7,
+      "price": 261000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "208": {
-      "price": 139000000000,
-      "level": 7,
+      "price": 282000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "209": {
-      "price": 140000000000,
-      "level": 7,
+      "price": 306000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "210": {
-      "price": 141000000000,
-      "level": 7,
+      "price": 331000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "211": {
-      "price": 142000000000,
-      "level": 7,
+      "price": 358000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "212": {
-      "price": 143000000000,
-      "level": 7,
+      "price": 388000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "213": {
-      "price": 144000000000,
-      "level": 7,
+      "price": 420000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "214": {
-      "price": 145000000000,
-      "level": 7,
+      "price": 455000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "215": {
-      "price": 146000000000,
-      "level": 7,
+      "price": 492000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "216": {
-      "price": 147000000000,
-      "level": 7,
+      "price": 533000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "217": {
-      "price": 148000000000,
-      "level": 7,
+      "price": 577000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "218": {
-      "price": 149000000000,
-      "level": 7,
+      "price": 624000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "219": {
-      "price": 150000000000,
-      "level": 7,
+      "price": 676000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "220": {
-      "price": 151000000000,
-      "level": 7,
+      "price": 732000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "221": {
-      "price": 152000000000,
-      "level": 7,
+      "price": 792000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "222": {
-      "price": 153000000000,
-      "level": 7,
+      "price": 858000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "223": {
-      "price": 154000000000,
-      "level": 7,
+      "price": 928000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "224": {
-      "price": 155000000000,
-      "level": 7,
+      "price": 1000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "225": {
-      "price": 156000000000,
-      "level": 7,
+      "price": 1080000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "226": {
-      "price": 157000000000,
-      "level": 7,
+      "price": 1170000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "227": {
-      "price": 158000000000,
-      "level": 7,
+      "price": 1270000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "228": {
-      "price": 159000000000,
-      "level": 7,
+      "price": 1380000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "229": {
-      "price": 160000000000,
-      "level": 7,
+      "price": 1490000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "230": {
-      "price": 161000000000,
-      "level": 7,
+      "price": 1610000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "231": {
-      "price": 162000000000,
-      "level": 7,
+      "price": 1750000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "232": {
-      "price": 163000000000,
-      "level": 7,
+      "price": 1890000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "233": {
-      "price": 164000000000,
-      "level": 7,
+      "price": 2050000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "234": {
-      "price": 165000000000,
-      "level": 7,
+      "price": 2220000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "235": {
-      "price": 166000000000,
-      "level": 7,
+      "price": 2400000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "236": {
-      "price": 167000000000,
-      "level": 7,
+      "price": 2600000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "237": {
-      "price": 168000000000,
-      "level": 7,
+      "price": 2810000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "238": {
-      "price": 169000000000,
-      "level": 7,
+      "price": 3050000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "239": {
-      "price": 170000000000,
-      "level": 7,
+      "price": 3300000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "240": {
-      "price": 171000000000,
-      "level": 7,
+      "price": 3570000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "241": {
-      "price": 172000000000,
-      "level": 7,
+      "price": 3860000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "242": {
-      "price": 173000000000,
-      "level": 7,
+      "price": 4180000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "243": {
-      "price": 174000000000,
-      "level": 7,
+      "price": 4530000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "244": {
-      "price": 175000000000,
-      "level": 7,
+      "price": 4900000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "245": {
-      "price": 176000000000,
-      "level": 7,
+      "price": 5310000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "246": {
-      "price": 177000000000,
-      "level": 7,
+      "price": 5750000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "247": {
-      "price": 178000000000,
-      "level": 7,
+      "price": 6220000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "248": {
-      "price": 179000000000,
-      "level": 7,
+      "price": 6730000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "249": {
-      "price": 180000000000,
-      "level": 7,
+      "price": 7290000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 8.00
       }
     },
     "250": {
-      "price": 181000000000,
-      "level": 7,
+      "price": 7890000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "251": {
-      "price": 182000000000,
-      "level": 7,
+      "price": 8540000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "252": {
-      "price": 183000000000,
-      "level": 7,
+      "price": 9250000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "253": {
-      "price": 184000000000,
-      "level": 7,
+      "price": 10000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "254": {
-      "price": 185000000000,
-      "level": 7,
+      "price": 10800000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "255": {
-      "price": 186000000000,
-      "level": 7,
+      "price": 11700000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "256": {
-      "price": 187000000000,
-      "level": 7,
+      "price": 12700000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "257": {
-      "price": 188000000000,
-      "level": 7,
+      "price": 13700000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "258": {
-      "price": 189000000000,
-      "level": 7,
+      "price": 14800000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "259": {
-      "price": 190000000000,
-      "level": 7,
+      "price": 16100000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "260": {
-      "price": 191000000000,
-      "level": 7,
+      "price": 17400000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "261": {
-      "price": 192000000000,
-      "level": 7,
+      "price": 18800000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "262": {
-      "price": 193000000000,
-      "level": 7,
+      "price": 20400000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "263": {
-      "price": 194000000000,
-      "level": 7,
+      "price": 22100000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "264": {
-      "price": 195000000000,
-      "level": 7,
+      "price": 23900000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "265": {
-      "price": 196000000000,
-      "level": 7,
+      "price": 25900000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "266": {
-      "price": 197000000000,
-      "level": 7,
+      "price": 28000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "267": {
-      "price": 198000000000,
-      "level": 7,
+      "price": 30300000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "268": {
-      "price": 199000000000,
-      "level": 7,
+      "price": 32800000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "269": {
-      "price": 200000000000,
-      "level": 7,
+      "price": 35600000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "270": {
-      "price": 201000000000,
-      "level": 7,
+      "price": 38500000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "271": {
-      "price": 202000000000,
-      "level": 7,
+      "price": 41700000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "272": {
-      "price": 203000000000,
-      "level": 7,
+      "price": 45100000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "273": {
-      "price": 204000000000,
-      "level": 7,
+      "price": 48900000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "274": {
-      "price": 205000000000,
-      "level": 7,
+      "price": 52900000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "275": {
-      "price": 206000000000,
-      "level": 7,
+      "price": 57300000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "276": {
-      "price": 207000000000,
-      "level": 7,
+      "price": 62000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "277": {
-      "price": 208000000000,
-      "level": 7,
+      "price": 67100000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "278": {
-      "price": 209000000000,
-      "level": 7,
+      "price": 72600000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "279": {
-      "price": 210000000000,
-      "level": 7,
+      "price": 78600000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "280": {
-      "price": 211000000000,
-      "level": 7,
+      "price": 85100000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "281": {
-      "price": 212000000000,
-      "level": 7,
+      "price": 92200000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "282": {
-      "price": 213000000000,
-      "level": 7,
+      "price": 100000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "283": {
-      "price": 214000000000,
-      "level": 7,
+      "price": 108000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "284": {
-      "price": 215000000000,
-      "level": 7,
+      "price": 116000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "285": {
-      "price": 216000000000,
-      "level": 7,
+      "price": 126000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "286": {
-      "price": 217000000000,
-      "level": 7,
+      "price": 137000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "287": {
-      "price": 218000000000,
-      "level": 7,
+      "price": 148000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "288": {
-      "price": 219000000000,
-      "level": 7,
+      "price": 160000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "289": {
-      "price": 220000000000,
-      "level": 7,
+      "price": 173000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "290": {
-      "price": 221000000000,
-      "level": 7,
+      "price": 188000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "291": {
-      "price": 222000000000,
-      "level": 7,
+      "price": 20300000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "292": {
-      "price": 223000000000,
-      "level": 7,
+      "price": 22000000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "293": {
-      "price": 224000000000,
-      "level": 7,
+      "price": 23800000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "294": {
-      "price": 225000000000,
-      "level": 7,
+      "price": 25800000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "295": {
-      "price": 226000000000,
-      "level": 7,
+      "price": 27900000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "296": {
-      "price": 227000000000,
-      "level": 7,
+      "price": 30200000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "297": {
-      "price": 228000000000,
-      "level": 7,
+      "price": 32700000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "298": {
-      "price": 229000000000,
-      "level": 7,
+      "price": 35400000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "299": {
-      "price": 230000000000,
-      "level": 7,
+      "price": 38400000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "300": {
-      "price": 231000000000,
-      "level": 7,
+      "price": 41500000000000000,
+      "level": 50,
       "boosters": {
         "EXPLOSIONS": 1.25,
         "MONEY": 1.25,
         "BLOCKS": 1.25,
-        "EXP": 1.25
+        "EXP": 10.00
       }
     },
     "301": {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the price and level attributes for levels 201-300 in `destructions/rebirth.json` and increase the "EXP" booster value for these levels.

### Why are these changes being made?

This change standardizes level progression by significantly increasing the levels from 7 to 50 and adjusts the prices to reflect the new level scheme. Increasing the "EXP" booster from 1.25 to 8.00 or 10.00 provides a more substantial incentive for players advancing through these levels, addressing feedback on the existing scale of rewards which was inadequate for higher level completeness.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->